### PR TITLE
Fix line calling GPAW: Use mpiexec OR -P option to gpaw, not both.

### DIFF
--- a/benchmarks/MoS2-benchmark.sh
+++ b/benchmarks/MoS2-benchmark.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 #SBATCH --job-name=MoS2-benchmark
 #SBATCH --mail-type=START,END
-#SBATCH --partition=xeon40_clx
+#SBATCH --partition=xeon56
 #SBATCH --output=%x-%j.out
 #SBATCH --time=6:00:00
 #SBATCH --nodes=1
-#SBATCH --ntasks=40
+#SBATCH --ntasks=56
 #SBATCH --cpus-per-task=1
-#SBATCH --mem=350G
 
 # This is a Slurm batch job script for the MoS2-benchmark.py benchmark.
 # It is assumed that a GPAW software module can be loaded.
@@ -33,7 +32,7 @@ printenv|grep SLURM
 export OMP_NUM_THREADS=1
 
 echo Running GPAW with $SLURM_NTASKS tasks.
-mpiexec gpaw -P $SLURM_NTASKS python MoS2-benchmark.py
+mpiexec gpaw python MoS2-benchmark.py
 
 echo Extract numbers for correctness and timing
 grep Free MoS2-benchmark.txt

--- a/benchmarks/Ru2Cl6-benchmark.sh
+++ b/benchmarks/Ru2Cl6-benchmark.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 #SBATCH --job-name=Ru2Cl6-benchmark
 #SBATCH --mail-type=START,END
-#SBATCH --partition=xeon40_clx
+#SBATCH --partition=xeon56
 #SBATCH --output=%x-%j.out
 #SBATCH --time=6:00:00
 #SBATCH --nodes=1
-#SBATCH --ntasks=40
+#SBATCH --ntasks=56
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=50G
 
@@ -35,7 +35,7 @@ export OMP_NUM_THREADS=1
 
 # mpiexec gpaw-python Ru2Cl6-benchmark.py
 echo Running GPAW with $SLURM_NTASKS tasks.
-mpiexec gpaw -P $SLURM_NTASKS python Ru2Cl6-benchmark.py
+mpiexec gpaw python Ru2Cl6-benchmark.py
 # Remove data file
 rm -f Ru2Cl6-benchmark.gpw
 


### PR DESCRIPTION
The line calling gpaw in the scripts should not use the -P option to gpaw:
```
mpiexec gpaw -P $SLURM_NTASKS python Ru2Cl6-benchmark.py
```
as that causes gpaw to call mpiexec, but mpiexec has already been called.  The ``-P`` option is for manually running in parallel.  Under slurm and the like it is easiest to just call ``mpiexec`` and let it get the number of nodes directly from slurm.  So I changed the line to:
```
mpiexec gpaw python Ru2Cl6-benchmark.py
```

@OleHolmNielsen Is there a reason to explicitly write `mpiexec -n $SLURM_NTASKS` to make it more visible how to run it outside slurm?

