### PR TITLE
Update kpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,9 +327,9 @@ The GPAW code records the elapsed wall-clock time and prints it at the end of
 the output files, for example:
 ```
 $ grep Total: MoS2-benchmark.txt
-Total:                                      5460.698 100.0%
+Total:                                      5055.608 100.0%
 $ grep Total: Ru2Cl6-benchmark.txt 
-Total:                                       548.079 100.0%
+Total:                                      1179.073 100.0%
 ```
 
 These ```Total:``` timings for Benchmarks 1 and 2, executed with both the foss-2022a and intel-2022a toolchains,

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Free energy:   -1287.277410
 Benchmark 2:
 ```
 $ grep Free Ru2Cl6-benchmark.txt
-Free energy:    -28.475998
+Free energy:    -28.476802
 ```
 
 It is expected that the mentioned numbers should vary only in the last digit by a small amount.

--- a/benchmarks/MoS2-benchmark.sh
+++ b/benchmarks/MoS2-benchmark.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 #SBATCH --job-name=MoS2-benchmark
 #SBATCH --mail-type=START,END
-#SBATCH --partition=xeon40_clx
+#SBATCH --partition=xeon56
 #SBATCH --output=%x-%j.out
 #SBATCH --time=6:00:00
 #SBATCH --nodes=1
-#SBATCH --ntasks=40
+#SBATCH --ntasks=56
 #SBATCH --cpus-per-task=1
-#SBATCH --mem=350G
 
 # This is a Slurm batch job script for the MoS2-benchmark.py benchmark.
 # It is assumed that a GPAW software module can be loaded.
@@ -33,7 +32,7 @@ printenv|grep SLURM
 export OMP_NUM_THREADS=1
 
 echo Running GPAW with $SLURM_NTASKS tasks.
-mpiexec gpaw -P $SLURM_NTASKS python MoS2-benchmark.py
+mpiexec gpaw python MoS2-benchmark.py
 
 echo Extract numbers for correctness and timing
 grep Free MoS2-benchmark.txt

--- a/benchmarks/Ru2Cl6-benchmark.py
+++ b/benchmarks/Ru2Cl6-benchmark.py
@@ -36,7 +36,7 @@ def get_mm(atoms, state):
 def pbeU(tag=None):
     U = 4.0
     ecut = 1200
-    kdens = 12
+    kdens = 18
     width = 0.01
     atoms = read('Ru2Cl6-input.json')
     mm = get_mm(atoms, 'afm')

--- a/benchmarks/Ru2Cl6-benchmark.sh
+++ b/benchmarks/Ru2Cl6-benchmark.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 #SBATCH --job-name=Ru2Cl6-benchmark
 #SBATCH --mail-type=START,END
-#SBATCH --partition=xeon40_clx
+#SBATCH --partition=xeon56
 #SBATCH --output=%x-%j.out
 #SBATCH --time=6:00:00
 #SBATCH --nodes=1
-#SBATCH --ntasks=40
+#SBATCH --ntasks=56
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=50G
 
@@ -35,7 +35,7 @@ export OMP_NUM_THREADS=1
 
 # mpiexec gpaw-python Ru2Cl6-benchmark.py
 echo Running GPAW with $SLURM_NTASKS tasks.
-mpiexec gpaw -P $SLURM_NTASKS python Ru2Cl6-benchmark.py
+mpiexec gpaw python Ru2Cl6-benchmark.py
 # Remove data file
 rm -f Ru2Cl6-benchmark.gpw
 


### PR DESCRIPTION
Number of k-points increased to decrease variance if number of cores does not match number of irreducible k-points.  With this change the error due to some cores needing to calculate one more k-point than others is around 3% with realistic core numbers.

This changed the last digits of the total energy, the  `README.md` files has been updated to reflect this.  Also, the timings have been updated to realistic number so it does not wrongly gives the impression that the RuCl6 is much faster than it really is.
 