### PR TITLE
Update pytest.ini to gpaw version 22.8.0

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,15 +2,3 @@
 addopts = --doctest-modules
 testpaths = gpaw
 norecursedirs = big
-markers =
-    soc: Spin-orbit coupling
-    slow: slow test
-    fast: fast test
-    ci: test for CI
-    libxc: LibXC requirered
-    mgga: MGGA test
-    dscf: Delta-SCF
-    gllb: GLLBSC tests
-    elph: Electron-phonon
-    intel: fails on INTEL toolchain
-    serial: run in serial only


### PR DESCRIPTION
Some information has been moved out of ``pytest.ini`` in newer GPAW versions, for more reliable pytest runs.
